### PR TITLE
Create composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,23 @@
+{
+  "name": "joshlevinson/pmp-roles",
+  "description": "PMPro Roles - Addon for Paid Memberships Pro - Adds a WordPress Role for each Membership Level",
+  "homepage": "https://github.com/joshlevinson/pmp-roles",
+  "version": "0.2",
+  "license": "GPL-2.0",
+  "authors": [
+    {
+      "name": "Josh Levinson",
+      "homepage": "https://github.com/joshlevinson"
+    }
+  ],
+  "support": {
+    "issues": "https://github.com/joshlevinson/pmp-roles/issues"
+  },
+  "type": "wordpress-plugin",
+  "require": {
+    "php": ">=5.3.2",
+    "composer/installers": "~1.0.12",
+    "johnpbloch/wordpress": ">=3.0",
+    "wpackagist-plugin/paid-memberships-pro": ">=1.8.8.3"
+  }
+}


### PR DESCRIPTION
Add composer support for developers using PHP package management with WordPress.
